### PR TITLE
[windows] __builtin_offsetof not defined on Windows

### DIFF
--- a/rosidl_typesupport_introspection_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_cpp/CMakeLists.txt
@@ -15,6 +15,10 @@ ament_python_install_package(${PROJECT_NAME})
 include_directories(include)
 add_library(rosidl_typesupport_introspection_cpp SHARED src/identifier.cpp)
 ament_export_libraries(rosidl_typesupport_introspection_cpp)
+if(WIN32)
+  target_compile_definitions(rosidl_typesupport_introspection_cpp
+    PRIVATE "ROSIDL_TSI_CPP_BUILDING_DLL")
+endif()
 
 if(AMENT_ENABLE_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -39,6 +43,7 @@ install(
 )
 install(
   TARGETS rosidl_typesupport_introspection_cpp
-  LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )

--- a/rosidl_typesupport_introspection_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_cpp/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(rosidl_typesupport_introspection_cpp)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)

--- a/rosidl_typesupport_introspection_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_cpp/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 
-project(rosidl_typesupport_introspection_cpp)
-
-if(NOT WIN32)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-endif()
+project(rosidl_typesupport_introspection_cpp NONE)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
@@ -15,12 +11,6 @@ ament_export_include_directories(include include/${PROJECT_NAME}/impl)
 ament_python_install_package(${PROJECT_NAME})
 
 include_directories(include)
-add_library(rosidl_typesupport_introspection_cpp SHARED src/identifier.cpp)
-ament_export_libraries(rosidl_typesupport_introspection_cpp)
-if(WIN32)
-  target_compile_definitions(rosidl_typesupport_introspection_cpp
-    PRIVATE "ROSIDL_TSI_CPP_BUILDING_DLL")
-endif()
 
 if(AMENT_ENABLE_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -42,10 +32,4 @@ install(
 install(
   DIRECTORY include/
   DESTINATION include
-)
-install(
-  TARGETS rosidl_typesupport_introspection_cpp
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
 )

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -59,6 +59,10 @@ add_custom_command(
 set(_target_suffix "__typesupport_introspection_cpp")
 
 add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} SHARED ${_generated_files})
+if(WIN32)
+  target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    PRIVATE "ROSIDL_TSI_CPP_BUILDING_DLL")
+endif()
 target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -87,7 +87,9 @@ add_dependencies(
 
 install(
   TARGETS ${rosidl_generate_interfaces_TARGET}${_target_suffix}
-  DESTINATION "lib"
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 ament_export_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix})

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/Identifier.h
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/Identifier.h
@@ -1,0 +1,11 @@
+#ifndef ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_IDENTIFIER_H_
+#define ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_IDENTIFIER_H_
+
+namespace rosidl_typesupport_introspection_cpp
+{
+
+static const char * typesupport_introspection_identifier = "introspection";
+
+}  // namespace rosidl_typesupport_introspection_cpp
+
+#endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_IDENTIFIER_H_

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/MessageIntrospection.h
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/MessageIntrospection.h
@@ -6,14 +6,14 @@
 
 #include <rosidl_generator_c/message_type_support.h>
 
+#include "impl/visibility_control.h"
+
 namespace rosidl_typesupport_introspection_cpp
 {
 
-extern const char * typesupport_introspection_identifier;
+struct ROSIDL_TSI_CPP_PUBLIC MessageMembers;
 
-struct MessageMembers;
-
-typedef struct MessageMember
+typedef struct ROSIDL_TSI_CPP_PUBLIC MessageMember
 {
   const char * name_;
   uint8_t type_id_;
@@ -26,7 +26,7 @@ typedef struct MessageMember
   const void * default_value_;
 } MessageMember;
 
-typedef struct MessageMembers
+typedef struct ROSIDL_TSI_CPP_PUBLIC MessageMembers
 {
   const char * package_name_;
   const char * message_name_;
@@ -35,6 +35,7 @@ typedef struct MessageMembers
 } MessageMembers;
 
 template<typename T>
+ROSIDL_TSI_CPP_PUBLIC
 const rosidl_message_type_support_t * get_type_support_handle();
 
 }  // namespace rosidl_typesupport_introspection_cpp

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/ServiceIntrospection.h
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/ServiceIntrospection.h
@@ -5,12 +5,13 @@
 #include <rosidl_generator_c/service_type_support.h>
 #include <rosidl_generator_cpp/ServiceTypeSupport.h>
 
+#include "impl/visibility_control.h"
+
 namespace rosidl_typesupport_introspection_cpp
 {
 
-extern const char * typesupport_introspection_identifier;
-
 template<typename T>
+ROSIDL_TSI_CPP_PUBLIC
 const rosidl_service_type_support_t * get_service_type_support_handle();
 
 }  // namespace rosidl_typesupport_introspection_cpp

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/impl/visibility_control.h
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/impl/visibility_control.h
@@ -37,14 +37,11 @@ extern "C"
       #define ROSIDL_TSI_CPP_PUBLIC __declspec(dllexport)
     #endif
   #else
-    #ifdef __GNUC__
-      #define ROSIDL_TSI_CPP_PUBLIC __attribute__ ((dllimport))
-    #else
-      #define ROSIDL_TSI_CPP_PUBLIC __declspec(dllimport)
-    #endif
+    #define ROSIDL_TSI_CPP_PUBLIC ROSIDL_TSI_CPP_DLLIMPORT
   #endif
   #define ROSIDL_TSI_CPP_LOCAL
 #else
+  #define ROSIDL_TSI_CPP_DLLIMPORT __attribute__ ((visibility ("hidden")))
   #if __GNUC__ >= 4
     #define ROSIDL_TSI_CPP_PUBLIC __attribute__ ((visibility ("default")))
     #define ROSIDL_TSI_CPP_LOCAL __attribute__ ((visibility ("hidden")))

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/impl/visibility_control.h
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/impl/visibility_control.h
@@ -1,0 +1,61 @@
+/* Copyright 2015 Open Source Robotics Foundation, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __rosidl_typesupport_introspection_cpp__impl__visibility_control__h__
+#define __rosidl_typesupport_introspection_cpp__impl__visibility_control__h__
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_TSI_CPP_DLLIMPORT __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_TSI_CPP_DLLIMPORT __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_TSI_CPP_BUILDING_DLL
+    #ifdef __GNUC__
+      #define ROSIDL_TSI_CPP_PUBLIC __attribute__ ((dllexport))
+    #else
+      #define ROSIDL_TSI_CPP_PUBLIC __declspec(dllexport)
+    #endif
+  #else
+    #ifdef __GNUC__
+      #define ROSIDL_TSI_CPP_PUBLIC __attribute__ ((dllimport))
+    #else
+      #define ROSIDL_TSI_CPP_PUBLIC __declspec(dllimport)
+    #endif
+  #endif
+  #define ROSIDL_TSI_CPP_LOCAL
+#else
+  #if __GNUC__ >= 4
+    #define ROSIDL_TSI_CPP_PUBLIC __attribute__ ((visibility ("default")))
+    #define ROSIDL_TSI_CPP_LOCAL __attribute__ ((visibility ("hidden")))
+  #else
+    #define ROSIDL_TSI_CPP_PUBLIC
+    #define ROSIDL_TSI_CPP_LOCAL
+  #endif
+#endif
+
+#if __cplusplus
+}
+#endif
+
+#endif  // __rosidl_typesupport_introspection_cpp__impl__visibility_control__h__

--- a/rosidl_typesupport_introspection_cpp/resource/msg_TypeSupport_Introspection.cpp.template
+++ b/rosidl_typesupport_introspection_cpp/resource/msg_TypeSupport_Introspection.cpp.template
@@ -15,23 +15,15 @@
 #ifndef __@(spec.base_type.pkg_name)__@(spec.base_type.type)_TypeSupport__h__
 #define __@(spec.base_type.pkg_name)__@(spec.base_type.type)_TypeSupport__h__
 
+// Include cstddef for offsetof().
+#include <cstddef>
+
 #include "@(spec.base_type.pkg_name)/@(spec.base_type.type)_Struct.h"
 #include "rosidl_generator_cpp/MessageTypeSupport.h"
 #include "rosidl_typesupport_introspection_cpp/FieldTypes.h"
 #include "rosidl_typesupport_introspection_cpp/Identifier.h"
 #include "rosidl_typesupport_introspection_cpp/MessageIntrospection.h"
 #include "rosidl_typesupport_introspection_cpp/impl/visibility_control.h"
-
-@{
-import os
-
-IS_WINDOWS = os.name == 'nt'
-
-if not IS_WINDOWS:
-    print('#ifndef offsetof')
-    print('  #define offsetof __builtin_offsetof')
-    print('#endif')
-}@
 
 namespace @(spec.base_type.pkg_name)
 {

--- a/rosidl_typesupport_introspection_cpp/resource/msg_TypeSupport_Introspection.cpp.template
+++ b/rosidl_typesupport_introspection_cpp/resource/msg_TypeSupport_Introspection.cpp.template
@@ -20,6 +20,15 @@
 #include "rosidl_typesupport_introspection_cpp/FieldTypes.h"
 #include "rosidl_typesupport_introspection_cpp/MessageIntrospection.h"
 
+@{
+import os
+
+IS_WINDOWS = os.name == 'nt'
+
+if not IS_WINDOWS:
+    print('#define offsetof __builtin_offsetof')
+}@
+
 namespace @(spec.base_type.pkg_name)
 {
 
@@ -55,7 +64,7 @@ for index, field in enumerate(spec.fields):
     # bool is_upper_bound_
     print('        %s,' % ('true' if field.type.is_upper_bound else 'false'))
     # unsigned long offset_
-    print('        __builtin_offsetof(%s::%s, %s)' % (spec.base_type.pkg_name, spec.base_type.type, field.name))
+    print('        offsetof(%s::%s, %s)' % (spec.base_type.pkg_name, spec.base_type.type, field.name))
 
     if index < len(spec.fields) - 1:
         print('    },')

--- a/rosidl_typesupport_introspection_cpp/resource/msg_TypeSupport_Introspection.cpp.template
+++ b/rosidl_typesupport_introspection_cpp/resource/msg_TypeSupport_Introspection.cpp.template
@@ -18,6 +18,7 @@
 #include "@(spec.base_type.pkg_name)/@(spec.base_type.type)_Struct.h"
 #include "rosidl_generator_cpp/MessageTypeSupport.h"
 #include "rosidl_typesupport_introspection_cpp/FieldTypes.h"
+#include "rosidl_typesupport_introspection_cpp/Identifier.h"
 #include "rosidl_typesupport_introspection_cpp/MessageIntrospection.h"
 #include "rosidl_typesupport_introspection_cpp/impl/visibility_control.h"
 
@@ -31,14 +32,6 @@ if not IS_WINDOWS:
     print('  #define offsetof __builtin_offsetof')
     print('#endif')
 }@
-
-namespace rosidl_typesupport_introspection_cpp
-{
-
-ROSIDL_TSI_CPP_DLLIMPORT
-const char * typesupport_introspection_identifier;
-
-}  // namespace rosidl_generator_cpp
 
 namespace @(spec.base_type.pkg_name)
 {

--- a/rosidl_typesupport_introspection_cpp/resource/msg_TypeSupport_Introspection.cpp.template
+++ b/rosidl_typesupport_introspection_cpp/resource/msg_TypeSupport_Introspection.cpp.template
@@ -27,7 +27,9 @@ import os
 IS_WINDOWS = os.name == 'nt'
 
 if not IS_WINDOWS:
-    print('#define offsetof __builtin_offsetof')
+    print('#ifndef offsetof')
+    print('  #define offsetof __builtin_offsetof')
+    print('#endif')
 }@
 
 namespace rosidl_typesupport_introspection_cpp

--- a/rosidl_typesupport_introspection_cpp/resource/msg_TypeSupport_Introspection.cpp.template
+++ b/rosidl_typesupport_introspection_cpp/resource/msg_TypeSupport_Introspection.cpp.template
@@ -19,6 +19,7 @@
 #include "rosidl_generator_cpp/MessageTypeSupport.h"
 #include "rosidl_typesupport_introspection_cpp/FieldTypes.h"
 #include "rosidl_typesupport_introspection_cpp/MessageIntrospection.h"
+#include "rosidl_typesupport_introspection_cpp/impl/visibility_control.h"
 
 @{
 import os
@@ -28,6 +29,14 @@ IS_WINDOWS = os.name == 'nt'
 if not IS_WINDOWS:
     print('#define offsetof __builtin_offsetof')
 }@
+
+namespace rosidl_typesupport_introspection_cpp
+{
+
+ROSIDL_TSI_CPP_DLLIMPORT
+const char * typesupport_introspection_identifier;
+
+}  // namespace rosidl_generator_cpp
 
 namespace @(spec.base_type.pkg_name)
 {
@@ -99,6 +108,7 @@ namespace rosidl_typesupport_introspection_cpp
 {
 
 template<>
+ROSIDL_TSI_CPP_PUBLIC
 const rosidl_message_type_support_t * get_type_support_handle<@(spec.base_type.pkg_name)::@(spec.base_type.type)>()
 {
     return &::@(spec.base_type.pkg_name)::rosidl_typesupport_introspection_cpp::@(spec.base_type.type)_message_type_support_handle;

--- a/rosidl_typesupport_introspection_cpp/src/identifier.cpp
+++ b/rosidl_typesupport_introspection_cpp/src/identifier.cpp
@@ -1,10 +1,12 @@
 #include <stdint.h>
 
 #include "rosidl_typesupport_introspection_cpp/FieldTypes.h"
+#include "rosidl_typesupport_introspection_cpp/impl/visibility_control.h"
 
 namespace rosidl_typesupport_introspection_cpp
 {
 
+ROSIDL_TSI_CPP_PUBLIC
 const char * typesupport_introspection_identifier = "introspection";
 
 }  // namespace rosidl_typesupport_introspection_cpp


### PR DESCRIPTION
This pull request adds support for Windows. The first thing I've found is that Windows does not have the `__builtin_offsetof` symbol, so the `offsetof` symbol is used instead.

This is a work in progress, it isn't fully building yet.

Connects to ros2/ros2#9
