### PR TITLE
fix warning from rti code generator

### DIFF
--- a/rosidl_generator_dds_idl/rosidl_generator_dds_idl/__init__.py
+++ b/rosidl_generator_dds_idl/rosidl_generator_dds_idl/__init__.py
@@ -86,7 +86,7 @@ def get_include_directives(spec, subfolders):
     for field in spec.fields:
         if field.type.is_primitive_type():
             continue
-        include_directive = '#include "%s/%s_.idl";' % \
+        include_directive = '#include "%s/%s_.idl"' % \
             ('/'.join([field.type.pkg_name] + subfolders), field.type.type)
         include_directives.add(include_directive)
     return sorted(include_directives)


### PR DESCRIPTION
Fix warning:

```
warning: extra tokens at end of #include directive [enabled by default]
```
