### PR TITLE
Added support for bounded string idl_types within bounded sequences.

### DIFF
--- a/rosidl_generator_dds_idl/rosidl_generator_dds_idl/__init__.py
+++ b/rosidl_generator_dds_idl/rosidl_generator_dds_idl/__init__.py
@@ -168,20 +168,25 @@ def msg_type_to_idl(type_):
     @param type: The message type
     @type type: rosidl_parser.Type
     """
+    string_upper_bound = None
     if type_.is_primitive_type():
         idl_type = MSG_TYPE_TO_IDL[type_.type]
+        if type_.type == 'string' and not type_.string_upper_bound == None:
+            string_upper_bound = type_.string_upper_bound
     else:
         if type_.type.endswith('_Request') or type_.type.endswith('_Response'):
             idl_type = '%s::srv::dds_::%s_' % (type_.pkg_name, type_.type)
         else:
             idl_type = '%s::msg::dds_::%s_' % (type_.pkg_name, type_.type)
-    return _msg_type_to_idl(type_, idl_type)
+    return _msg_type_to_idl(type_, idl_type, string_upper_bound)
 
 
-def _msg_type_to_idl(type_, idl_type):
+def _msg_type_to_idl(type_, idl_type, type_string_upper_bound=None):
     if type_.is_array:
         if type_.array_size is None or type_.is_upper_bound:
             sequence_type = idl_type
+            if not type_string_upper_bound == None:
+                sequence_type += '<%s>' % type_string_upper_bound
             if type_.is_upper_bound:
                 sequence_type += ', %u' % type_.array_size
             return ['', '', 'sequence<%s>' % sequence_type]


### PR DESCRIPTION
I am working on a project where we had began switching over to utilizing the ament build system and rwm_connext. We are using the RTI DDS middleware and a problem arose that needed the feature this change allows. I had created a ticket in Waffle (#36 for the ros2/rosidl_dds package)

Excuse if any of my pull-request etiquette is off, this is my first contribution to an open source project and I hope a great learning experience.
