### PR TITLE
support sequences of upper bounded strings

### DIFF
--- a/rosidl_generator_dds_idl/rosidl_generator_dds_idl/__init__.py
+++ b/rosidl_generator_dds_idl/rosidl_generator_dds_idl/__init__.py
@@ -168,20 +168,25 @@ def msg_type_to_idl(type_):
     @param type: The message type
     @type type: rosidl_parser.Type
     """
+    string_upper_bound = None
     if type_.is_primitive_type():
         idl_type = MSG_TYPE_TO_IDL[type_.type]
+        if type_.type == 'string' and not type_.string_upper_bound == None:
+            string_upper_bound = type_.string_upper_bound
     else:
         if type_.type.endswith('_Request') or type_.type.endswith('_Response'):
             idl_type = '%s::srv::dds_::%s_' % (type_.pkg_name, type_.type)
         else:
             idl_type = '%s::msg::dds_::%s_' % (type_.pkg_name, type_.type)
-    return _msg_type_to_idl(type_, idl_type)
+    return _msg_type_to_idl(type_, idl_type, string_upper_bound)
 
 
-def _msg_type_to_idl(type_, idl_type):
+def _msg_type_to_idl(type_, idl_type, type_string_upper_bound=None):
     if type_.is_array:
         if type_.array_size is None or type_.is_upper_bound:
             sequence_type = idl_type
+            if not type_string_upper_bound == None:
+                sequence_type += '<%s>' % type_string_upper_bound
             if type_.is_upper_bound:
                 sequence_type += ', %u' % type_.array_size
             return ['', '', 'sequence<%s>' % sequence_type]

--- a/rosidl_generator_dds_idl/rosidl_generator_dds_idl/__init__.py
+++ b/rosidl_generator_dds_idl/rosidl_generator_dds_idl/__init__.py
@@ -171,22 +171,22 @@ def msg_type_to_idl(type_):
     string_upper_bound = None
     if type_.is_primitive_type():
         idl_type = MSG_TYPE_TO_IDL[type_.type]
-        if type_.type == 'string' and not type_.string_upper_bound == None:
+        if type_.type == 'string' and type_.string_upper_bound is not None:
             string_upper_bound = type_.string_upper_bound
     else:
         if type_.type.endswith('_Request') or type_.type.endswith('_Response'):
             idl_type = '%s::srv::dds_::%s_' % (type_.pkg_name, type_.type)
         else:
             idl_type = '%s::msg::dds_::%s_' % (type_.pkg_name, type_.type)
-    return _msg_type_to_idl(type_, idl_type, string_upper_bound)
+    return _msg_type_to_idl(type_, idl_type, string_upper_bound=string_upper_bound)
 
 
-def _msg_type_to_idl(type_, idl_type, type_string_upper_bound=None):
+def _msg_type_to_idl(type_, idl_type, string_upper_bound=None):
     if type_.is_array:
         if type_.array_size is None or type_.is_upper_bound:
             sequence_type = idl_type
-            if not type_string_upper_bound == None:
-                sequence_type += '<%s>' % type_string_upper_bound
+            if string_upper_bound is not None:
+                sequence_type += '<%s>' % string_upper_bound
             if type_.is_upper_bound:
                 sequence_type += ', %u' % type_.array_size
             return ['', '', 'sequence<%s>' % sequence_type]

--- a/rosidl_generator_dds_idl/rosidl_generator_dds_idl/__init__.py
+++ b/rosidl_generator_dds_idl/rosidl_generator_dds_idl/__init__.py
@@ -189,7 +189,9 @@ def _msg_type_to_idl(type_, idl_type, string_upper_bound=None):
                 sequence_type += '<%s>' % string_upper_bound
             if type_.is_upper_bound:
                 sequence_type += ', %u' % type_.array_size
-            return ['', '', 'sequence<%s>' % sequence_type]
+            return [
+                '', '',
+                'sequence<%s%s>' % (sequence_type, ' ' if sequence_type.endswith('>') else '')]
         else:
             typename = '%s_array_%s' % \
                 (idl_type.replace(' ', '_').replace('::', '__'), type_.array_size)


### PR DESCRIPTION
This replaces #37 and fixes #36. The second commit only updates the code style a bit. The second commit fixes a problem with unbounded sequences since the `.idl` parsers seem to not support `>>`. Changing the generated code to `> >` works.

* [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2110)](http://ci.ros2.org/job/ci_linux/2110/)
* [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1628)](http://ci.ros2.org/job/ci_osx/1628/)
* [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2122)](http://ci.ros2.org/job/ci_windows/2122/)

The numerous new test failures are unrelated to this patch (all for `rmw_fastrtps`) and like a result of a recent change in FastRTPS (https://github.com/eProsima/Fast-RTPS/commit/9d655e0b02affdc86218f8ccaabf206efc5f4c64).